### PR TITLE
fix missed sha512 value to the astree function of File

### DIFF
--- a/sflock/abstracts.py
+++ b/sflock/abstracts.py
@@ -732,6 +732,7 @@ class File(object):
             "safelisted": self.safelisted,
             "safelist_reason": self.safelist_reason,
             "sha256": self.sha256,
+            "sha512": self.sha512,
             "md5": self.md5,
             "sha1": self.sha1,
             "type": "container" if self.children else "file",


### PR DESCRIPTION
while adding sha512 to sflock I missed the [function astree](https://github.com/cert-ee/sflock/blob/05d5f52dbf73a50e35f9fc3566a4a8358091a91e/sflock/abstracts.py#L714). This fixes https://github.com/cert-ee/cuckoo3/issues/87.